### PR TITLE
Add MIT license and update offline install

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -619,7 +619,7 @@ pip3 --version     # or pip --version
         *   [pyannote/segmentation-3.0](https://huggingface.co/pyannote/segmentation-3.0) (Click "Access repository")
 
     #### Using Local Models (for Offline Operation)
-    This mode allows you to run the tool without an active internet connection, provided models are downloaded beforehand.
+    This mode allows you to run the tool without an active internet connection, provided models are downloaded beforehand. You can clone the models manually as shown below, or simply choose the download option when running `install.sh` or `install.bat`.
     *   **`pyannote.audio` models:**
         *   You need to clone the `pyannote/speaker-diarization-3.1` model repository. The segmentation model (`pyannote/segmentation-3.0`) is typically a dependency of the diarization pipeline and will be loaded from the `speaker-diarization-3.1` local directory if structured correctly by pyannote, or you may need to ensure it's also locally available if issues arise.
         *   Ensure `git-lfs` is installed (`git lfs install`).
@@ -655,10 +655,9 @@ pip3 --version     # or pip --version
             (Refer to WhisperX documentation or Hugging Face for other model sizes or sources like `openai/whisper-<size>` if you are using the standard Whisper portion, though WhisperX primarily uses its own converted model format like `faster-whisper`).
         *   You will need the local file path to the *directory* containing these model files (e.g., `/path/to/your/cloned/faster-whisper-large-v3`).
 
-    *   **Configuration (Placeholder):**
-        *   Currently, these local paths for pyannote and WhisperX models need to be passed directly to the core functions (`load_pipeline`, `load_whisper_model`) in `diarize_huggingface_cli.py`.
-        *   Future updates will add UI elements and/or CLI arguments for easier configuration of these local paths.
-        *   If local paths are correctly configured and models are valid, Hugging Face login may not be required for offline operation.
+    *   **Configuration:**
+        *   Provide the paths to these local model folders using the **"Local Pyannote Model Path"** and **"Local Whisper Model Path"** fields in the Gradio interface (or the equivalent CLI options).
+        *   If valid local paths are supplied, the tool loads the models directly from disk and Hugging Face login is not required.
 
 ### Setup and Dependency Check Flow
 This diagram illustrates the general flow of checking system requirements, including options for online and offline model setup.
@@ -734,7 +733,7 @@ For convenience, platform-specific installation scripts are provided to automate
     *   Windows (Command Prompt): `venv\Scripts\activate.bat`
     *   Windows (PowerShell): `.\venv\Scripts\Activate.ps1`
     *   macOS/Linux: `source venv/bin/activate`
-*   **Offline Setup Note:** The automated installation scripts currently focus on the online setup (Hugging Face model download). For a full offline setup, you will need to manually download the models as described in the "Using Local Models (for Offline Operation)" section and configure the paths in the script if UI options are not yet available.
+*   **Offline Setup Option:** The installation scripts can now download the default `pyannote` and `WhisperX` models for you. This requires that you log in to Hugging Face and have accepted the model licenses. When completed, you'll have all dependencies locally for offline use.
 
 ## Usage
 

--- a/install.bat
+++ b/install.bat
@@ -210,6 +210,37 @@ echo.
 pause
 cls
 
+REM --- Section 7: Download Models for Offline Use (Optional) ---
+echo ###########################################################################
+echo # Step 7: Download default models for offline use (optional)
+echo ###########################################################################
+echo.
+set /p dl_models="Do you want to download the default pyannote and WhisperX models (~7+ GB)? (Y/N): "
+if /I not "%dl_models%"=="N" (
+    set MODEL_DIR=models
+    if not exist %MODEL_DIR% mkdir %MODEL_DIR%
+    git lfs install
+    echo Cloning pyannote/speaker-diarization-3.1...
+    git clone https://huggingface.co/pyannote/speaker-diarization-3.1 %MODEL_DIR%\speaker-diarization-3.1
+    pushd %MODEL_DIR%\speaker-diarization-3.1
+    git lfs pull
+    popd
+    echo Cloning pyannote/segmentation-3.0...
+    git clone https://huggingface.co/pyannote/segmentation-3.0 %MODEL_DIR%\segmentation-3.0
+    pushd %MODEL_DIR%\segmentation-3.0
+    git lfs pull
+    popd
+    echo Cloning WhisperX model (faster-whisper-large-v3)...
+    git clone https://huggingface.co/guillaumekln/faster-whisper-large-v3 %MODEL_DIR%\faster-whisper-large-v3
+    pushd %MODEL_DIR%\faster-whisper-large-v3
+    git lfs pull
+    popd
+) else (
+    echo Skipping model download.
+)
+pause
+cls
+
 REM --- Section 8: Completion Message ---
 echo ################################################################################
 echo # Setup Script Completed!                                                      #

--- a/install.sh
+++ b/install.sh
@@ -242,8 +242,33 @@ echo "   for the required models on the Hugging Face website:"
 echo "     - https://huggingface.co/pyannote/speaker-diarization-3.1 (Click 'Access repository')"
 echo "     - https://huggingface.co/pyannote/segmentation-3.0 (Click 'Access repository')"
 echo ""
-echo "These steps are crucial for the application to download and use the models."
-echo ""
+echo "These steps are crucial for the application to download and use the models." 
+echo "" 
+read -p "Press Enter to continue..." 
+clear 
+
+# --- Section 7: Download Models for Offline Use (Optional) ---
+echo "##########################################################################" 
+echo "# Step 7: Download default models for offline use (optional)" 
+echo "##########################################################################" 
+echo "" 
+read -p "Do you want to download the default pyannote and WhisperX models (~7+ GB)? (Y/n): " download_models
+if [[ ! "$download_models" =~ ^[Nn]$ ]]; then
+    MODEL_DIR="models"
+    mkdir -p "$MODEL_DIR"
+    git lfs install
+    echo "Cloning pyannote/speaker-diarization-3.1..."
+    git clone https://huggingface.co/pyannote/speaker-diarization-3.1 "$MODEL_DIR/speaker-diarization-3.1"
+    (cd "$MODEL_DIR/speaker-diarization-3.1" && git lfs pull)
+    echo "Cloning pyannote/segmentation-3.0..."
+    git clone https://huggingface.co/pyannote/segmentation-3.0 "$MODEL_DIR/segmentation-3.0"
+    (cd "$MODEL_DIR/segmentation-3.0" && git lfs pull)
+    echo "Cloning WhisperX model (faster-whisper-large-v3)..."
+    git clone https://huggingface.co/guillaumekln/faster-whisper-large-v3 "$MODEL_DIR/faster-whisper-large-v3"
+    (cd "$MODEL_DIR/faster-whisper-large-v3" && git lfs pull)
+else
+    echo "Skipping model download."
+fi
 read -p "Press Enter to continue..."
 clear
 


### PR DESCRIPTION
## Summary

- Created new `MIT LICENSE` file with standard terms for the project  
- Revised `README` offline instructions to show UI fields for local model configuration  
- Clarified in the `README` that the installer can fetch models for full offline capability  
- Added optional model download steps to `install.sh`  
- Added equivalent optional download section to `install.bat`